### PR TITLE
Removing getResources as CompoundEnumeration is now a package class

### DIFF
--- a/capsule-util/src/main/java/co/paralleluniverse/common/FlexibleClassLoader.java
+++ b/capsule-util/src/main/java/co/paralleluniverse/common/FlexibleClassLoader.java
@@ -73,14 +73,6 @@ public abstract class FlexibleClassLoader extends ClassLoader {
     }
 
     @Override
-    public Enumeration<URL> getResources(String name) throws IOException {
-        Enumeration[] tmp = new Enumeration[2];
-        tmp[childFirst ? 1 : 0] = super.getResources(name);
-        tmp[childFirst ? 0 : 1] = findResources1(name);
-        return new sun.misc.CompoundEnumeration<URL>(tmp);
-    }
-
-    @Override
     protected Class<?> findClass(String name) throws ClassNotFoundException {
         Class<?> clazz = findLoadedClass(name);
         if (clazz == null) {


### PR DESCRIPTION
When building using openjdk-11 for the Debian packaging, I had to remove the definition of getResources as it needs the class CompoundEnumeration, which is not public from openjdk-11.

I am fully aware of the fact that removing this definition just fixes the build but is not satisfactory as getResources might be needed by your users.