### PR TITLE
Modifying packages of two classes after switching to jdk11

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -5408,10 +5408,10 @@ public class Capsule implements Runnable, InvocationHandler {
             // final JMXConnectorServer jmxServer = JMXConnectorServerFactory.newJMXConnectorServer(new JMXServiceURL("rmi", null, 0), null, ManagementFactory.getPlatformMBeanServer());
             // jmxServer.start(); // prevents the app from shutting down (requires jmxServer.stop()). See ConnectorBootstrap.PermanentExporter
             // url = jmxServer.getAddress();
-            final Properties agentProps = sun.misc.VMSupport.getAgentProperties();
+            final Properties agentProps = jdk.internal.vm.VMSupport.getAgentProperties();
             if (agentProps.get(LOCAL_CONNECTOR_ADDRESS_PROP) == null) {
                 log(LOG_VERBOSE, "Starting management agent");
-                sun.management.Agent.agentmain(null); // starts a JMXConnectorServer that does not prevent the app from shutting down
+                jdk.internal.agent.Agent.agentmain(null); // starts a JMXConnectorServer that does not prevent the app from shutting down
             }
             url = new JMXServiceURL((String) agentProps.get(LOCAL_CONNECTOR_ADDRESS_PROP));
 


### PR DESCRIPTION
The packages of the classes Agent and VMSupport have changed when switching from jdk-8 to jdk-11.

Of course, as for my previous MR, considering this patch only makes sense if you plan to switch to most modern jdks for the build.