### PR TITLE
Hardening version regex

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -4252,7 +4252,7 @@ public class Capsule implements Runnable, InvocationHandler {
         return true;
     }
 
-    private static final Pattern PAT_JAVA_VERSION = Pattern.compile("(?<major>\\d+)(\\.(?<minor>\\d+))?(?:\\.(?<patch>\\d+))?(_(?<update>\\d+))?(-(?<pre>[^-]+))?(-(?<build>.+))?");
+    private static final Pattern PAT_JAVA_VERSION = Pattern.compile("(?<major>\\d+)(\\.(?<minor>\\d+))?(?:\\.(?<patch>\\d+))?[0-9.]*(_(?<update>\\d+))?(-(?<pre>[^-]+))?(-(?<build>.+))?");
 
     // visible for testing
     static int[] parseJavaVersion(String v) {

--- a/capsule/src/test/java/CapsuleTest.java
+++ b/capsule/src/test/java/CapsuleTest.java
@@ -1292,6 +1292,10 @@ public class CapsuleTest {
         ver = Capsule.parseJavaVersion("1.8.0_30-ea");
         assertArrayEquals(ver, ints(1, 8, 0, 30, -3));
         assertEquals("1.8.0_30-ea", Capsule.toJavaVersionString(ver));
+
+        ver = Capsule.parseJavaVersion("11.0.14.1");
+        assertArrayEquals(ver, ints(1, 11, 14, 0, 0));
+        assertEquals("1.11.14", Capsule.toJavaVersionString(ver));
     }
 
     @Test


### PR DESCRIPTION
Hi,

In order to match jdk versions such that 11.0.14.1 (which is currently in Debian unstable), the version regex should be changed a bit. Here is a proposal.

Best regards,
Pierre